### PR TITLE
feature(jre): Make JRE installation up/downgradable

### DIFF
--- a/prudentia/tasks/jre.yml
+++ b/prudentia/tasks/jre.yml
@@ -25,7 +25,7 @@
 
   - name: Java JRE | Fail if it isn't x64
     fail: msg="Unknown platform architecture (should be x64, got {{ansible_architecture}}"
-    when: platform != "x64" and ansible_os_family == "Debian" and java_present|failed
+    when: (platform is not defined or platform != "x64") and ansible_os_family == "Debian" and java_present|failed
     tags: jre
 
   - name: Java JRE | Set download URL
@@ -52,6 +52,6 @@
       - "update-alternatives --install /usr/bin/java java /usr/lib/jvm/{{java_dir.stdout}}/bin/java 1"
       - "update-alternatives --set javac /usr/lib/jvm/{{java_dir.stdout}}/bin/javac"
       - "update-alternatives --set java /usr/lib/jvm/{{java_dir.stdout}}/bin/java"
-    when: ansible_os_family == "Debian" and java_present|failed
+    when: ansible_os_family == "Debian"
     sudo: yes
     tags: jre

--- a/prudentia/tasks/jre.yml
+++ b/prudentia/tasks/jre.yml
@@ -3,8 +3,15 @@
   #  java_jre_version (provided)
   #  java_jre_build (provided)
 
-  - name: Java JRE | Check if is present
-    command: test -x /usr/bin/java
+  - name: Java JRE | Get JRE directory name
+    shell: "echo jdk1.{{java_jre_version}} |sed 's/u/.0_/'"
+    register: java_dir
+    when: ansible_os_family == "Debian"
+    sudo: yes
+    tags: jre
+
+  - name: Java JRE | Check if it is present
+    command: test -d /usr/lib/jvm/{{java_dir.stdout}}
     when: ansible_system == "Linux"
     ignore_errors: yes
     register: java_present
@@ -25,13 +32,6 @@
     set_fact:
       jre_download_url: "http://download.oracle.com/otn-pub/java/jdk/{{java_jre_version}}-{{java_jre_build}}/server-jre-{{java_jre_version}}-linux-{{platform}}.tar.gz"
     when: ansible_os_family == "Debian" and java_present|failed
-    tags: jre
-
-  - name: Java JRE | Get directory name
-    shell: "echo jdk1.{{java_jre_version}} |sed 's/u/.0_/'"
-    register: java_dir
-    when: ansible_os_family == "Debian" and java_present|failed
-    sudo: yes
     tags: jre
 
   - name: Java JRE | Download and install


### PR DESCRIPTION
Tested. Works

First run. Install JRE8 update 66
```
vagrant@10-2-2-15:~$ java -version
java version "1.8.0_66"
Java(TM) SE Runtime Environment (build 1.8.0_66-b17)
Java HotSpot(TM) 64-Bit Server VM (build 25.66-b17, mixed mode)
vagrant@10-2-2-15:~$
```

Second run. Install JRE8 update 65
```
vagrant@10-2-2-15:~$ java -version
java version "1.8.0_65"
Java(TM) SE Runtime Environment (build 1.8.0_65-b17)
Java HotSpot(TM) 64-Bit Server VM (build 25.65-b01, mixed mode)
vagrant@10-2-2-15:~$
```

Both versions present:
```
vagrant@10-2-2-15:~$ ls /usr/lib/jvm/
jdk1.8.0_65  jdk1.8.0_66
vagrant@10-2-2-15:~$
```

In case of emergency it's easy to go back to previous version. Just specify it and run playbook.