### PR TITLE
provide defaults for "image" and "provider" keys

### DIFF
--- a/prudentia/vagrant.py
+++ b/prudentia/vagrant.py
@@ -225,6 +225,6 @@ class VagrantExt(object):
         ext = VagrantExt()
         ext.set_mem(json['mem'])
         ext.set_shares(json['shares'])
-        ext.set_image(json['image'])
-        ext.set_provider(json['provider'])
+        ext.set_image(json.get('image'))
+        ext.set_provider(json.get('provider'))
         return ext


### PR DESCRIPTION
Encountered this issue after I have upgraded from the version which did not have these keys in Vagrant environment yet.