### PR TITLE
fix(ntpdate): Parametrize ntp servers

### DIFF
--- a/prudentia/tasks/timezone.yml
+++ b/prudentia/tasks/timezone.yml
@@ -1,7 +1,8 @@
 ---
   # Parameters:
   #  prudentia_dir (provided)
-  #  tz
+  #  tz: time zone
+  #  ntp_server_address: ntp server address(es) (provided)
   #
   # Example usage:
   #  - include: "{{prudentia_dir}}/tasks/timezone.yml tz={{tz}}"
@@ -19,7 +20,7 @@
     tags: timezone
 
   - name: Schedule daily NTP update
-    cron: name="ntp-update" hour="1" job="/usr/sbin/ntpdate pool.ntp.org ntp.ubuntu.com > /dev/null"
+    cron: name="ntp-update" hour="1" job="/usr/sbin/ntpdate {{ntp_server_address}} > /dev/null"
     when: ansible_os_family == "Debian"
     sudo: yes
     tags: timezone

--- a/prudentia/tasks/timezone.yml
+++ b/prudentia/tasks/timezone.yml
@@ -19,7 +19,7 @@
     tags: timezone
 
   - name: Schedule daily NTP update
-    cron: name="ntp-update" hour="1" job="/usr/sbin/ntpdate ntp.ubuntu.com pool.ntp.org > /dev/null"
+    cron: name="ntp-update" hour="1" job="/usr/sbin/ntpdate pool.ntp.org ntp.ubuntu.com > /dev/null"
     when: ansible_os_family == "Debian"
     sudo: yes
     tags: timezone

--- a/prudentia/vars/global.yml
+++ b/prudentia/vars/global.yml
@@ -55,3 +55,5 @@
 
   haproxy_version: 1.5
   haproxy_apt_repository: ppa:vbernat/haproxy-{{haproxy_version}}
+
+  ntp_server_address: "pool.ntp.org ntp.ubuntu.com"


### PR DESCRIPTION
Switch first priority to pool.ntp.org as ntp.ubuntu.com is often busy.
Parametrize this as a variable

Observed live at the customer during last month