### PR TITLE
Feature/231 amend mongodb 3 task

### DIFF
--- a/prudentia/tasks/mongodb_3.yml
+++ b/prudentia/tasks/mongodb_3.yml
@@ -1,7 +1,7 @@
 ---
   # Parameters:
   #  prudentia_dir (provided)
-  #  mongodb_version (provided)
+  #  mongodb3_version (provided)
 
   - name: MongoDB | Check if is present
     command: test -x /usr/bin/mongo

--- a/prudentia/tasks/mongodb_3.yml
+++ b/prudentia/tasks/mongodb_3.yml
@@ -3,7 +3,7 @@
   #  prudentia_dir (provided)
   #  mongodb3_version (provided)
 
-  - name: MongoDB | Check if is present
+  - name: MongoDB 3 | Check if is present
     command: test -x /usr/bin/mongo
     when: ansible_system == "Linux"
     ignore_errors: yes
@@ -11,20 +11,20 @@
     tags:
       - mongodb3
 
-  - name: MongoDB | Add GPG key to apt keyring
+  - name: MongoDB 3 | Add GPG key to apt keyring
     apt_key: id=7F0CEB10 url=http://docs.mongodb.org/10gen-gpg-key.asc
     sudo: yes
     tags:
       - mongodb3
 
-  - name: MongoDB | Add Debian apt repository
+  - name: MongoDB 3 | Add Debian apt repository
     apt_repository: repo="deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/{{mongodb3_version}} multiverse"
     when: ansible_os_family == "Debian" and mongo_present|failed
     sudo: yes
     tags:
       - mongodb3
 
-  - name: MongoDB | Install
+  - name: MongoDB 3 | Install
     apt: update-cache=yes force=yes state=present pkg=mongodb-org
     when: ansible_os_family == "Debian" and mongo_present|failed
     sudo: yes

--- a/prudentia/tasks/mongodb_3.yml
+++ b/prudentia/tasks/mongodb_3.yml
@@ -1,27 +1,32 @@
 ---
   # Parameters:
   #  prudentia_dir (provided)
+  #  mongodb_version (provided)
 
   - name: MongoDB | Check if is present
     command: test -x /usr/bin/mongo
     when: ansible_system == "Linux"
     ignore_errors: yes
     register: mongo_present
-    tags: mongodb3
+    tags:
+      - mongodb3
 
   - name: MongoDB | Add GPG key to apt keyring
     apt_key: id=7F0CEB10 url=http://docs.mongodb.org/10gen-gpg-key.asc
     sudo: yes
-    tags: mongodb3
+    tags:
+      - mongodb3
 
   - name: MongoDB | Add Debian apt repository
-    apt_repository: repo="deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/3.0 multiverse"
+    apt_repository: repo="deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/{{mongodb3_version}} multiverse"
     when: ansible_os_family == "Debian" and mongo_present|failed
-    tags: mongodb3
     sudo: yes
+    tags:
+      - mongodb3
 
   - name: MongoDB | Install
     apt: update-cache=yes force=yes state=present pkg=mongodb-org
     when: ansible_os_family == "Debian" and mongo_present|failed
     sudo: yes
-    tags: mongodb3
+    tags:
+      - mongodb3

--- a/prudentia/vars/global.yml
+++ b/prudentia/vars/global.yml
@@ -57,3 +57,5 @@
   haproxy_apt_repository: ppa:vbernat/haproxy-{{haproxy_version}}
 
   ntp_server_address: "pool.ntp.org ntp.ubuntu.com"
+
+  mongodb3_version: 3.0


### PR DESCRIPTION
Customer requires MongoDB 3.2, which is not possible with current tasks.
Changes:
- Slightly modify `tasks/mongodb_3.yml` to use parametrised version
- Default `mongodb3_version` to `3.0` in `vars/global.yml`

Tested on the Customer - works.