### PR TITLE
refactor(jre): Address ansible 2 deprecation warning

### DIFF
--- a/prudentia/tasks/jre.yml
+++ b/prudentia/tasks/jre.yml
@@ -22,20 +22,20 @@
   - name: Java JRE | Are we running on x64?
     set_fact:
       platform: "x64"
-    when: ansible_architecture == "x86_64" and ansible_os_family == "Debian" and java_present|failed
+    when: ansible_architecture == "x86_64" and ansible_os_family == "Debian"
     tags:
       - jre
 
   - name: Java JRE | Fail if it isn't x64
     fail: msg="Unknown platform architecture (should be x64, got {{ansible_architecture}}"
-    when: (platform is not defined or platform != "x64") and ansible_os_family == "Debian" and java_present|failed
+    when: (platform is not defined or platform != "x64") and ansible_os_family == "Debian"
     tags:
       - jre
 
   - name: Java JRE | Set download URL
     set_fact:
       jre_download_url: "http://download.oracle.com/otn-pub/java/jdk/{{java_jre_version}}-{{java_jre_build}}/server-jre-{{java_jre_version}}-linux-{{platform}}.tar.gz"
-    when: ansible_os_family == "Debian" and java_present|failed
+    when: ansible_os_family == "Debian"
     tags:
       - jre
 


### PR DESCRIPTION
When running jre.yml task and JRE installation already exists, ansible 2 throws the following deprecation warning
```
TASK [Java JRE | Check if it is present] ***************************************
changed: [app-build.tradecloud.nl]

TASK [Java JRE | Are we running on x64?] ***************************************
skipping: [app-build.tradecloud.nl]

TASK [Java JRE | Fail if it isn't x64] *****************************************
skipping: [app-build.tradecloud.nl]

TASK [Java JRE | Set download URL] *********************************************
skipping: [app-build.tradecloud.nl]

TASK [Java JRE | Download and install] *****************************************
[DEPRECATION WARNING]: Skipping task due to undefined Error, in the future this
 will be a fatal error.: 'jre_download_url' is undefined.
This feature will be 
removed in a future release. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
```

After applying this fix:
```
TASK [Java JRE | Check if it is present] ***************************************
changed: [app-build.tradecloud.nl]

TASK [Java JRE | Are we running on x64?] ***************************************
ok: [app-build.tradecloud.nl]

TASK [Java JRE | Fail if it isn't x64] *****************************************
skipping: [app-build.tradecloud.nl]

TASK [Java JRE | Set download URL] *********************************************
ok: [app-build.tradecloud.nl]

TASK [Java JRE | Download and install] *****************************************
skipping: [app-build.tradecloud.nl] => (item=mkdir -p /usr/lib/jvm) 
skipping: [app-build.tradecloud.nl] => (item=wget -O /usr/lib/jvm/jdk1.8.0_92.tgz --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u92-b14/server-jre-8u92-linux-x64.tar.gz) 
skipping: [app-build.tradecloud.nl] => (item=cd /usr/lib/jvm && tar -zxf jdk1.8.0_92.tgz) 
skipping: [app-build.tradecloud.nl] => (item=rm -f /usr/lib/jvm/jdk1.8.0_92.tgz) 
```